### PR TITLE
syntax highlight, matchit config and formatoptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Automatic detection of `.vala`, `.vapi` and `.valadoc` files.
 ## Syntax highlighting
 
 * Methods: any word followed by `(`
+* Lambda expressions: `(...) =>`
 * Arrays, lists and hash tables as in `Array<int>`, `List<string>` and `HashTable<string, int>`
 * Operators and Delimiters: `+`, `-`, `*`, `/`, `=`, `( )`, `[ ]`, `{ }`...
 * String formatting in `printf`-like methods: `%d`, `%f`, `%s`, `%c`, `%u`, `%%`...

--- a/ftplugin/vala.vim
+++ b/ftplugin/vala.vim
@@ -5,6 +5,11 @@ let b:did_ftplugin = 1
 
 setlocal efm=%f:%l.%c-%[%^:]%#:\ %t%[%^:]%#:\ %m
 
+" When the matchit plugin is loaded, this makes the % command skip parens and
+" braces in comments.
+let b:match_words = '^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>'
+let b:match_skip = 's:comment\|string\|character\|special'
+
 " Insert a CCode attribute for the symbol below the cursor
 " https://wiki.gnome.org/Projects/Vala/LegacyBindings
 function! CCode() abort

--- a/ftplugin/vala.vim
+++ b/ftplugin/vala.vim
@@ -3,7 +3,17 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal formatoptions=t formatoptions+=croql
+" j was only added in 7.3.541, so stop complaints about its nonexistence
+" Where it makes sense, remove a comment leader when joining lines.
+silent! setlocal formatoptions+=j
+
 setlocal efm=%f:%l.%c-%[%^:]%#:\ %t%[%^:]%#:\ %m
+
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:O//
+setlocal commentstring=//%s
 
 " When the matchit plugin is loaded, this makes the % command skip parens and
 " braces in comments.

--- a/ftplugin/vala.vim
+++ b/ftplugin/vala.vim
@@ -23,3 +23,10 @@ command! -buffer -bar ValaCodingStyle call ValaCodingStyle()
 if get(g:, 'vala_syntax_folding_enabled', 1)
   setlocal foldmethod=syntax
 endif
+
+" filter files in the browse dialog
+if (has("browsefilter")) && !exists("b:browsefilter")
+  let b:browsefilter = "Vala Source Files (*.vala)\t*.vala\n" .
+        \ "Vala Vapi Files (*.vapi)\t*.vapi\n" .
+        \ "All Files (*.*)\t*.*\n"
+endif

--- a/syntax/vala.vim
+++ b/syntax/vala.vim
@@ -46,7 +46,9 @@ syn keyword valaConstant		false null true
 " Exceptions
 syn keyword valaException		try catch finally throw
 " Unspecified Statements
-syn keyword valaUnspecifiedStatement	as base construct delete get in is lock new out params ref sizeof set this throws typeof using value var yield
+syn keyword valaUnspecifiedStatement	as base construct delete get in is lock new out params ref sizeof set this throws typeof value var yield
+" Includes
+syn match valaInclude			"^\s*\zs\<using\>\ze\s\w"
 " Arrays and Lists
 syn match   valaArray			"\(\w\(\w\)*\(\s\+\)\?<\)\+\(\(\s\+\)\?\w\(\w\)*\(?\|\*\)\?\(\,\)\?\)\+>\+"
 " Methods
@@ -170,6 +172,7 @@ hi def link valaModifier		StorageClass
 hi def link valaConstant		Constant
 hi def link valaException		Exception
 hi def link valaUnspecifiedStatement	Statement
+hi def link valaInclude			Include
 hi def link valaUnspecifiedKeyword	Keyword
 hi def link valaContextualStatement	Statement
 hi def link valaArray			StorageClass

--- a/syntax/vala.vim
+++ b/syntax/vala.vim
@@ -141,6 +141,10 @@ syn match   valaNumber			display "\(\<\d\+\.\d*\|\.\d\+\)\([eE][-+]\=\d\+\)\=[fF
 syn match   valaNumber			display "\<\d\+[eE][-+]\=\d\+[fFdD]\=\>"
 syn match   valaNumber			display "\<\d\+\([eE][-+]\=\d\+\)\=[fFdD]\>"
 
+" Lambda definitions (ported from java.vim)
+" needs to be defined after the parenthesis error catcher to work
+syn match valaLambdaDef "([a-zA-Z0-9_<>\[\], \t]*)\s*=>"
+
 " when wanted, highlight trailing white space
 if exists("vala_space_errors")
   if !exists("vala_no_trail_space_error")
@@ -177,6 +181,7 @@ hi def link valaUnspecifiedKeyword	Keyword
 hi def link valaContextualStatement	Statement
 hi def link valaArray			StorageClass
 hi def link valaMethod			Function
+hi def link valaLambdaDef		Function
 hi def link valaOperator		Operator
 hi def link valaDelimiter		Delimiter
 hi def link valaEnumField		Constant


### PR DESCRIPTION
Hi,
some changes which might help others.
- consider using keyword as Include
- highlight lambda expressions like methods
- add matchit config to ignore braces in comments
- filter for browse dialog in gvim
- insert  comment leader in multi line comments for <CR> & 'o'
  delete comment leader when possible if lines are merged via 'J'

