### PR TITLE
show valac base errors in syntax checker

### DIFF
--- a/syntax_checkers/vala/valac.vim
+++ b/syntax_checkers/vala/valac.vim
@@ -36,7 +36,8 @@ function! SyntaxCheckers_vala_valac_GetLocList() dict " {{{1
     let errorformat =
         \ '%A%f:%l.%c-%\d%\+.%\d%\+: %t%[a-z]%\+: %m,'.
         \ '%C%m,'.
-        \ '%Z%m'
+        \ '%Z%m,'.
+        \ 'error: %m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
show errors like "error: The namespace name `Gtk' could not be found"